### PR TITLE
Добавлен модульный тест на запрос с группировкой

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ __pycache__
 /tests/tests_results/
 /sphinx/_build/
 /dist/
+.env
+.vscode

--- a/mpsiemlib/modules/EventsAPI.py
+++ b/mpsiemlib/modules/EventsAPI.py
@@ -123,7 +123,7 @@ class EventsAPI(ModuleInterface, LoggingHandler):
                            'hostname="{}"'.format(self.__core_hostname))
             raise Exception('Core data request return None or has wrong response structure')
         
-        return {' | '.join(e['groups']):int(e['values'][0]) for e in response['rows']}
+        return {' | '.join(str(s) for s in e['groups']):int(e['values'][0]) for e in response['rows']}
 
     def get_events_by_filter(self, filter, fields, time_from, time_to, limit, offset) -> dict:
         """

--- a/tests/unit_events_api.py
+++ b/tests/unit_events_api.py
@@ -1,0 +1,42 @@
+import unittest
+from datetime import datetime
+
+import pytz
+
+from mpsiemlib.common import *
+from mpsiemlib.modules import MPSIEMWorker
+from tests.settings import creds_ldap, settings
+
+
+class TestEventsAPITestCase(unittest.TestCase):
+    __mpsiemworker = None
+    __module = None
+    __creds = creds_ldap
+    __settings = settings
+    __begin = 0
+    __end = 0
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.__mpsiemworker = MPSIEMWorker(cls.__creds, cls.__settings)
+        cls.__module = cls.__mpsiemworker.get_module(ModuleNames.EVENTSAPI)
+        cls.__end = round(datetime.now(tz=pytz.timezone(settings.local_timezone)).timestamp())
+        cls.__begin = cls.__end - 86400
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.__module.close()
+        
+    def test_get_events_groupped_by_fields(self):
+        groupping_fields = ['id']
+        result = self.__module.get_events_groupped_by_fields(
+            filter='normalized = true', 
+            group_by_fields=groupping_fields,
+            time_from=self.__begin, 
+            time_to=self.__end
+        )
+        self.assertGreater(len(result), 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
1) Добавлен простой модульный тест для проверки функционала по запросу сгруппированных событий.
2) Исправлена проблема при обработке `None` среди вернувшихся групп.