### PR TITLE
Feature/Added strict error handling when initializing modules.

### DIFF
--- a/mpsiemlib/modules/HealthMonitor.py
+++ b/mpsiemlib/modules/HealthMonitor.py
@@ -21,7 +21,11 @@ class HealthMonitor(ModuleInterface, LoggingHandler):
         self.__core_session = auth.sessions['core']
         self.__core_hostname = auth.creds.core_hostname
         self.__core_version = auth.get_core_version()
-        self.__kb_session = auth.connect(MPComponents.KB)
+        try:
+            self.__kb_session = auth.connect(MPComponents.KB)
+        except:
+            self.__kb_session = None
+            self.log.warning(f"Module HEALTH required 'Knowledge Base' component, which is unavailable. Check permissions or component availability.")
 
     def get_health_status(self) -> str:
         """Получить общее состояние системы.

--- a/mpsiemlib/modules/HealthMonitor.py
+++ b/mpsiemlib/modules/HealthMonitor.py
@@ -25,7 +25,7 @@ class HealthMonitor(ModuleInterface, LoggingHandler):
             self.__kb_session = auth.connect(MPComponents.KB)
         except:
             self.__kb_session = None
-            self.log.warning(f"Module HEALTH required 'Knowledge Base' component, which is unavailable. Check permissions or component availability.")
+            self.log.warning(f"Module [Health] required 'Knowledge Base' component, which is unavailable. Check permissions or component availability.")
 
     def get_health_status(self) -> str:
         """Получить общее состояние системы.

--- a/mpsiemlib/modules/__init__.py
+++ b/mpsiemlib/modules/__init__.py
@@ -32,8 +32,7 @@ class MPSIEMWorker(WorkerInterface, LoggingHandler):
                     else:
                         self.log.warning(f"Connection to {name} returned empty session. Skipping...")
                 except Exception as e:
-                    # In case of a 500 error or access denied from the kb (or any other) component
-                    self.log.error(f"Failed to connect to component {name}: {e}. Skipping this component.")
+                    self.log.warning(f"Failed to connect to component {name}: {e}. Skipping this component.")
         # if self.creds.siem_hostname:
         #     sessions['siem'] = self.__auth.connect(MPComponents.SIEM)
         # if self.creds.storage_hostname:
@@ -47,6 +46,32 @@ class MPSIEMWorker(WorkerInterface, LoggingHandler):
         if creds is not None:
             self.creds = creds
             auth = MPSIEMAuth(self.creds, self.settings)
+
+        dependencies = {
+            ModuleNames.URM: ['core'],
+            ModuleNames.ASSETS: ['core'],
+            ModuleNames.EVENTSAPI: ['core'],
+            ModuleNames.TABLES: ['core'],
+            ModuleNames.INCIDENTS: ['core'],
+            ModuleNames.FILTERS: ['core'],
+            ModuleNames.TASKS: ['core'],
+            ModuleNames.SOURCE_MONITOR: ['core'],
+            ModuleNames.CONVEYOR: ['core'],
+            ModuleNames.KB: ['kb'],
+            ModuleNames.HEALTH: ['core', 'kb'],
+            ModuleNames.MACROS: ['core', 'kb'],
+        }
+
+        # EVENTS (MP Storage (Elasticsearch))
+        if self.__module_name == ModuleNames.EVENTS:
+            if not self.creds.storage_hostname:
+                self.log.error("Module EVENTS requires 'storage_hostname' in credentials, but it is empty.")
+                return None
+
+        required_components = dependencies.get(module_name, [])
+        for component in required_components:
+            if component not in self.__auth.sessions:
+                self.log.warning(f"Module {module_name} required '{component}' component, which is unavailable. Check permissions or component availability.")
 
         if self.__module_name == ModuleNames.AUTH:
             return auth

--- a/mpsiemlib/modules/__init__.py
+++ b/mpsiemlib/modules/__init__.py
@@ -23,9 +23,17 @@ class MPSIEMWorker(WorkerInterface, LoggingHandler):
         self.__auth = MPSIEMAuth(self.creds, self.settings)
         sessions = {}
         if self.creds.core_hostname:
-            sessions['core'] = self.__auth.connect(MPComponents.CORE)
-            sessions['ms'] = self.__auth.connect(MPComponents.MS)
-            sessions['kb'] = self.__auth.connect(MPComponents.KB)
+            target_components = [('core', MPComponents.CORE), ('ms', MPComponents.MS), ('kb', MPComponents.KB)]
+            for name, component in target_components:
+                try:
+                    session = self.__auth.connect(component)
+                    if session:
+                        sessions[name] = session
+                    else:
+                        self.log.warning(f"Connection to {name} returned empty session. Skipping...")
+                except Exception as e:
+                    # In case of a 500 error or access denied from the kb (or any other) component
+                    self.log.error(f"Failed to connect to component {name}: {e}. Skipping this component.")
         # if self.creds.siem_hostname:
         #     sessions['siem'] = self.__auth.connect(MPComponents.SIEM)
         # if self.creds.storage_hostname:

--- a/mpsiemlib/modules/__init__.py
+++ b/mpsiemlib/modules/__init__.py
@@ -48,30 +48,37 @@ class MPSIEMWorker(WorkerInterface, LoggingHandler):
             auth = MPSIEMAuth(self.creds, self.settings)
 
         dependencies = {
-            ModuleNames.URM: ['core'],
             ModuleNames.ASSETS: ['core'],
-            ModuleNames.EVENTSAPI: ['core'],
-            ModuleNames.TABLES: ['core'],
-            ModuleNames.INCIDENTS: ['core'],
-            ModuleNames.FILTERS: ['core'],
-            ModuleNames.TASKS: ['core'],
-            ModuleNames.SOURCE_MONITOR: ['core'],
             ModuleNames.CONVEYOR: ['core'],
-            ModuleNames.KB: ['kb'],
+            ModuleNames.EVENTSAPI: ['core'],
+            ModuleNames.FILTERS: ['core'],
             ModuleNames.HEALTH: ['core', 'kb'],
+            ModuleNames.INCIDENTS: ['core'],
+            ModuleNames.KB: ['kb'],
             ModuleNames.MACROS: ['core', 'kb'],
+            ModuleNames.SOURCE_MONITOR: ['core'],
+            ModuleNames.TABLES: ['core'],
+            ModuleNames.TASKS: ['core'],
+            ModuleNames.URM: ['core'],
         }
 
-        # EVENTS (MP Storage (Elasticsearch))
         if self.__module_name == ModuleNames.EVENTS:
             if not self.creds.storage_hostname:
-                self.log.error("Module EVENTS requires 'storage_hostname' in credentials, but it is empty.")
-                return None
+                error_msg = f"Module {self.__module_name} requires 'storage_hostname' in credentials, but it is empty."
+                self.log.error(error_msg)
+                raise ValueError(error_msg)
 
-        required_components = dependencies.get(module_name, [])
-        for component in required_components:
-            if component not in self.__auth.sessions:
-                self.log.warning(f"Module {module_name} required '{component}' component, which is unavailable. Check permissions or component availability.")
+        required_components = dependencies.get(self.__module_name, [])
+        if required_components:
+            missing_components = [comp for comp in required_components if comp not in self.__auth.sessions]
+
+            if len(missing_components) == len(required_components):
+                error_msg = f"Module [{self.__module_name}] cannot be initialized. All required components {missing_components} are unavailable. Check permissions or component availability."
+                self.log.error(error_msg)
+                raise RuntimeError(error_msg)
+
+            elif len(missing_components) > 0:
+                self.log.warning(f"Module [{self.__module_name}] initialized with limited functionality. Missing components: {missing_components}. Some features may not work.")
 
         if self.__module_name == ModuleNames.AUTH:
             return auth


### PR DESCRIPTION
Fixes a problem with using the library when the MP account permissions are insufficient. It solves the connection crash (error 500) when Knowledge Base permissions are missing.
If the modules do not have all the required components to run, or if storage_hostname is empty for the EVENTS module, an exception is thrown depending on the type of error, RuntimeError or ValueError, to make it clear that the problem is in the configuration.
If only one of the components (for example, core, but not kb) is sufficient for some of the module's functions (for example, Health) to work, then get_module reports a warning and you can use some of the functions that do not require the missing component (for example, API functions in Health).
